### PR TITLE
Organization forget password

### DIFF
--- a/app/Http/Controllers/OrganizationForgetPassword.php
+++ b/app/Http/Controllers/OrganizationForgetPassword.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Foundation\Auth\ResetsPasswords;
+
+use App\Http\Requests;
+
+class OrganizationForgetPassword extends Controller
+{
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Controller
+    |--------------------------------------------------------------------------
+    |
+    | This controller is responsible for handling password reset requests by organizations
+    | and uses a simple trait to include this behavior.
+    |
+    */
+
+    use ResetsPasswords;
+
+    protected $guard = 'organizations';
+    protected $broker = 'organizations';
+    /**
+     * Create a new password controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('guest');
+    }
+
+
+    /**
+     * Display the form to request a password reset link.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function showLinkRequestForm()
+    {
+        if (property_exists($this, 'linkRequestView')) {
+            return view($this->linkRequestView);
+        }
+
+        if (view()->exists('auth.passwords.email_organization')) {
+            return view('auth.passwords.email_organization');
+        }
+
+        return view('auth.password');
+    }
+
+    protected function getSendResetLinkEmailFailureResponse($response)
+    {
+        return redirect()->back()->withErrors(['email' => 'Couldn\'t find an organization with that email.']);
+    }
+}

--- a/app/Http/Controllers/OrganizationForgetPassword.php
+++ b/app/Http/Controllers/OrganizationForgetPassword.php
@@ -21,8 +21,19 @@ class OrganizationForgetPassword extends Controller
 
     use ResetsPasswords;
 
-    protected $guard = 'organizations';
+    /**
+     * Determine the guard requesting password reset
+     * @var string
+     */
+    protected $guard = 'organization';
+
+    /**
+     * Determine the broker for the password reset
+     * @var string
+     */
     protected $broker = 'organizations';
+
+
     /**
      * Create a new password controller instance.
      *
@@ -52,8 +63,54 @@ class OrganizationForgetPassword extends Controller
         return view('auth.password');
     }
 
+    /**
+     * Display the password reset view for the given token.
+     *
+     * If no token is present, display the link request form.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  string|null  $token
+     * @return \Illuminate\Http\Response
+     */
+
+    public function showResetForm(Request $request, $token = null)
+    {
+        if (is_null($token)) {
+            return $this->getEmail();
+        }
+
+        $email = $request->input('email');
+
+        if (property_exists($this, 'resetView')) {
+            return view($this->resetView)->with(compact('token', 'email'));
+        }
+
+        if (view()->exists('auth.passwords.reset_organization')) {
+            return view('auth.passwords.reset_organization')->with(compact('token', 'email'));
+        }
+
+        return view('auth.reset')->with(compact('token', 'email'));
+    }
+
+    /**
+     * Specify the failure message if the email does not exist
+     * @param $response
+     * @return $this
+     */
+
     protected function getSendResetLinkEmailFailureResponse($response)
     {
         return redirect()->back()->withErrors(['email' => 'Couldn\'t find an organization with that email.']);
+    }
+
+
+    /**
+    * Specify the return path after resetting the password.
+    * @return $this
+    */
+
+    public function redirectPath()
+    {
+        return '/';
     }
 }

--- a/app/Http/Controllers/OrganizationPasswordController.php
+++ b/app/Http/Controllers/OrganizationPasswordController.php
@@ -52,11 +52,13 @@ class OrganizationForgetPassword extends Controller
      */
     public function showLinkRequestForm()
     {
-        if (property_exists($this, 'linkRequestView')) {
+        if (property_exists($this, 'linkRequestView'))
+        {
             return view($this->linkRequestView);
         }
 
-        if (view()->exists('auth.passwords.email_organization')) {
+        if (view()->exists('auth.passwords.email_organization'))
+        {
             return view('auth.passwords.email_organization');
         }
 
@@ -75,17 +77,20 @@ class OrganizationForgetPassword extends Controller
 
     public function showResetForm(Request $request, $token = null)
     {
-        if (is_null($token)) {
+        if (is_null($token))
+        {
             return $this->getEmail();
         }
 
         $email = $request->input('email');
 
-        if (property_exists($this, 'resetView')) {
+        if (property_exists($this, 'resetView'))
+        {
             return view($this->resetView)->with(compact('token', 'email'));
         }
 
-        if (view()->exists('auth.passwords.reset_organization')) {
+        if (view()->exists('auth.passwords.reset_organization'))
+        {
             return view('auth.passwords.reset_organization')->with(compact('token', 'email'));
         }
 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -137,6 +137,12 @@ Route::group(['middleware' => ['web']], function () {
         'show', 'edit', 'update',
     ]]);
 
+
+    /**
+     * Organization forget password
+     */
+    Route::get('/password_organization/reset','OrganizationForgetPassword@getEmail');
+    Route::post('/password_organization/email','OrganizationForgetPassword@sendResetLinkEmail');
 /*
 |-----------------------
 | Volunteer Routes
@@ -171,6 +177,8 @@ Route::group(['middleware' => ['web']], function () {
     Route::resource('volunteer','VolunteerController', ['only' => [
         'show',
     ]]);
+
+
 
 /*
 |-----------------------

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -63,6 +63,13 @@ Route::group(['middleware' => ['web']], function () {
     Route::get('logout_organization','OrganizationAuthController@logout');
 
     /**
+     * Organization forget password.
+     */
+    Route::get('/password_organization/reset','OrganizationPasswordController@getEmail');
+    Route::post('/password_organization/email','OrganizationPasswordController@sendResetLinkEmail');
+    Route::get('/password_organization/reset/{token}','OrganizationPasswordController@getReset');
+    Route::post('/password_organization/reset','OrganizationPasswordController@reset');
+    /**
      *  Volunteer Authentication (register/login/logout)
      */
     Route::auth();
@@ -137,14 +144,6 @@ Route::group(['middleware' => ['web']], function () {
         'show', 'edit', 'update',
     ]]);
 
-
-    /**
-     * Organization forget password
-     */
-    Route::get('/password_organization/reset','OrganizationForgetPassword@getEmail');
-    Route::post('/password_organization/email','OrganizationForgetPassword@sendResetLinkEmail');
-    Route::get('/password_organization/reset/{token}','OrganizationForgetPassword@getReset');
-    Route::post('/password_organization/reset','OrganizationForgetPassword@reset');
 /*
 |-----------------------
 | Volunteer Routes
@@ -179,8 +178,6 @@ Route::group(['middleware' => ['web']], function () {
     Route::resource('volunteer','VolunteerController', ['only' => [
         'show',
     ]]);
-
-
 
 /*
 |-----------------------

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -143,6 +143,8 @@ Route::group(['middleware' => ['web']], function () {
      */
     Route::get('/password_organization/reset','OrganizationForgetPassword@getEmail');
     Route::post('/password_organization/email','OrganizationForgetPassword@sendResetLinkEmail');
+    Route::get('/password_organization/reset/{token}','OrganizationForgetPassword@getReset');
+    Route::post('/password_organization/reset','OrganizationForgetPassword@reset');
 /*
 |-----------------------
 | Volunteer Routes

--- a/app/Organization.php
+++ b/app/Organization.php
@@ -3,9 +3,14 @@
 namespace App;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Contracts\Auth\CanResetPassword as CanResetPassword;
+use Illuminate\Auth\Passwords\CanResetPassword as CanResetPasswordTrait;
 
-class Organization extends Authenticatable
+class Organization extends Authenticatable implements CanResetPassword
 {
+
+    use CanResetPasswordTrait;
+
     protected $fillable = [
         'name', 'email', 'password','bio','slogan','phone','location'
     ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -114,6 +114,12 @@ return [
             'table' => 'password_resets',
             'expire' => 60,
         ],
+        'organizations' => [
+            'provider' => 'organizations',
+            'email' => 'auth.emails.password',
+            'table' => 'password_resets',
+            'expire' => 60,
+        ]
     ],
 
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -116,7 +116,7 @@ return [
         ],
         'organizations' => [
             'provider' => 'organizations',
-            'email' => 'auth.emails.password',
+            'email' => 'auth.emails.password_organization',
             'table' => 'password_resets',
             'expire' => 60,
         ]

--- a/config/mail.php
+++ b/config/mail.php
@@ -54,7 +54,7 @@ return [
     |
     */
 
-    'from' => ['address' => null, 'name' => null],
+    'from' => ['address' => 'mostafaabdullahahmed@gmail.com', 'name' => 'Kheir Blogger'],
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/auth/emails/password_organization.blade.php
+++ b/resources/views/auth/emails/password_organization.blade.php
@@ -1,0 +1,1 @@
+Click here to reset your password: <a href="{{ $link = url('password_organization/reset', $token).'?email='.urlencode($user->getEmailForPasswordReset()) }}"> {{ $link }} </a>

--- a/resources/views/auth/login_organization.blade.php
+++ b/resources/views/auth/login_organization.blade.php
@@ -54,7 +54,7 @@
                                     <i class="fa fa-btn fa-sign-in"></i>Login
                                 </button>
 
-                                <a class="btn btn-link" href="{{ url('/password/reset') }}">Forgot Your Password?</a>
+                                <a class="btn btn-link" href="{{ url('/password_organization/reset') }}">Forgot Your Password?</a>
                             </div>
                         </div>
                         @include('errors')  

--- a/resources/views/auth/passwords/email_organization.blade.php
+++ b/resources/views/auth/passwords/email_organization.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+
+<!-- Main Content -->
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Reset Password</div>
+                <div class="panel-body">
+                    @if (session('status'))
+                        <div class="alert alert-success">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
+                    <form class="form-horizontal" role="form" method="POST" action="{{ url('/password_organization/email') }}">
+                        {!! csrf_field() !!}
+
+                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
+                            <label class="col-md-4 control-label">E-Mail Address</label>
+
+                            <div class="col-md-6">
+                                <input type="email" class="form-control" name="email" value="{{ old('email') }}">
+
+                                @if ($errors->has('email'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-md-6 col-md-offset-4">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fa fa-btn fa-envelope"></i>Send Password Reset Link
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/passwords/reset_organization.blade.php
+++ b/resources/views/auth/passwords/reset_organization.blade.php
@@ -1,0 +1,70 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-md-offset-2">
+            <div class="panel panel-default">
+                <div class="panel-heading">Reset Password</div>
+
+                <div class="panel-body">
+                    <form class="form-horizontal" role="form" method="POST" action="{{ url('/password/reset') }}">
+                        {!! csrf_field() !!}
+
+                        <input type="hidden" name="token" value="{{ $token }}">
+
+                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
+                            <label class="col-md-4 control-label">E-Mail Address</label>
+
+                            <div class="col-md-6">
+                                <input type="email" class="form-control" name="email" value="{{ $email or old('email') }}">
+
+                                @if ($errors->has('email'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
+                            <label class="col-md-4 control-label">Password</label>
+
+                            <div class="col-md-6">
+                                <input type="password" class="form-control" name="password">
+
+                                @if ($errors->has('password'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('password') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
+                            <label class="col-md-4 control-label">Confirm Password</label>
+                            <div class="col-md-6">
+                                <input type="password" class="form-control" name="password_confirmation">
+
+                                @if ($errors->has('password_confirmation'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-md-6 col-md-offset-4">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fa fa-btn fa-refresh"></i>Reset Password
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/auth/passwords/reset_organization.blade.php
+++ b/resources/views/auth/passwords/reset_organization.blade.php
@@ -8,7 +8,7 @@
                 <div class="panel-heading">Reset Password</div>
 
                 <div class="panel-body">
-                    <form class="form-horizontal" role="form" method="POST" action="{{ url('/password/reset') }}">
+                    <form class="form-horizontal" role="form" method="POST" action="{{ url('/password_organization/reset') }}">
                         {!! csrf_field() !!}
 
                         <input type="hidden" name="token" value="{{ $token }}">


### PR DESCRIPTION
Organizations can now reset their password.
In order to activate this feature, you need to configure the mail server on your localhost:

1- Go to `.env` file
*\* Assuming you are using Gmail **
2- Make the email configuration as follows:
`
MAIL_DRIVER=smtp
MAIL_HOST=smtp.gmail.com
MAIL_PORT=587
MAIL_USERNAME=<< Your email here >>
MAIL_PASSWORD=<< Your password here >>
MAIL_ENCRYPTION=tls
`

3- Go to `config\mail.php`
Find this line
`'from' => ['address' => 'mostafaabdullahahmed@gmail.com', 'name' => 'Kheir Blogger'],`
And change the address to the email you entered in the `.env` file.

Now the volunteer and the organization can reset their password and the email is sent from your Gmail.
