### PR TITLE
#159 | added token refreshment

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,7 +15,8 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
-        \App\Http\Middleware\InputCleanup::class
+        \App\Http\Middleware\InputCleanup::class,
+        \App\Http\Middleware\RefreshToken::class
     ];
 
     /**

--- a/app/Http/Middleware/RefreshToken.php
+++ b/app/Http/Middleware/RefreshToken.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Tymon\JWTAuth\Exceptions\TokenInvalidException;
+use Tymon\JWTAuth\Token;
+
+use JWTAuth;
+use Closure;
+
+class RefreshToken
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $token = $request->header('x-access-token');
+        $response = $next($request);
+        if($token)
+        {
+            try
+            {
+                $token = JWTAuth::refresh(new Token($token));
+                $response->headers->set('x-access-token', $token);
+            }
+            catch(TokenInvalidException $e)
+            {
+
+            }
+        }
+        return $response;
+    }
+}


### PR DESCRIPTION
For every request that has a valid token as header `x-access-token`, the token will be refreshed: old token is blacklisted and a new token is attached in the response header `x-access-token`. Thus, old token must be discarded and new token is used instead.
